### PR TITLE
Fix fast jump to top and adding # to url on click

### DIFF
--- a/src/scripts/scrolld.js
+++ b/src/scripts/scrolld.js
@@ -47,7 +47,8 @@
         (function bindClicks() {
             var buttonsLength = buttons.length;
             for (var i = 0; i < buttonsLength; i++) {
-                $(buttons[i]).on('click', function() {
+                $(buttons[i]).on('click', function(e) {
+                    e.preventDefault();
                     update();
                     var targetID = $(this).data('scrolld');
                     var target = $('#' + targetID);


### PR DESCRIPTION
Add preventDefault for click event. If you have animation tied to scroll, without that it can start not in time.
